### PR TITLE
kodi-c1-fb: Bump to commit b00d3a6

### DIFF
--- a/alarm/kodi-c1-fb/PKGBUILD
+++ b/alarm/kodi-c1-fb/PKGBUILD
@@ -18,8 +18,8 @@ _prefix=/usr
 
 pkgbase=kodi-c1-fb
 pkgname=('kodi-c1-fb' 'kodi-c1-eventclients-fb')
-_commit=195486881941215f4081abf2992391dd6cfe8eef
-pkgver=15.0.20150817
+_commit=b00d3a6f7baed1b6c2a5569dd3c2cddc5f25effc
+pkgver=15.2.20150911
 pkgrel=1
 _codename=unknown
 arch=('armv7h')
@@ -42,7 +42,7 @@ source=("https://github.com/Owersun/xbmc/archive/${_commit}.tar.gz"
         'kodi_permissions.conf'
 	'20-quiet-printk.conf')
 
-sha256sums=('e8df5b75f08e62fc1166ccb352184b6a6a2a15bbcd986451d82bb1cdee8c883b'
+sha256sums=('d9aaa35cf9561d62677083f281b2e482c787e2e9052403d03ba4ce358ae12b1a'
             'SKIP'
             '79aa17b475967d97b6c72c850b638705d6feb6d995844476b65d68d33d161114'
             'c68ed2bd377f80b606b8815d78239b9132b479eafc1d19797cee5824debe1800'


### PR DESCRIPTION
Just bumping this to latest commit. Confirmed working on my ODROID-C1 (except for that nasty bug that prevents me from adding stuff to my library).

By the way, I'm not the only one experiencing this. It looks like this is some incompatibility between kodi >= 15.1 and gcc 5.2. There [are](https://github.com/archlinuxarm/PKGBUILDs/issues/1222) [multiple](http://forum.kodi.tv/showthread.php?tid=235883) [reports](http://archlinuxarm.org/forum/viewtopic.php?f=31&t=9201) on a variety of devices. I'll try compiling with gcc 5.1 as soon as I find packages for it (i already updated and cleared the cache unfortunately). Looks like that should fix the issue.
