### PR TITLE
Bump alarm/kodi-c1-fb to 16.0b2

### DIFF
--- a/alarm/kodi-c1-fb/0014-aml-Remove-dependency-on-libamplayer-and-amffmpeg.patch
+++ b/alarm/kodi-c1-fb/0014-aml-Remove-dependency-on-libamplayer-and-amffmpeg.patch
@@ -1,0 +1,179 @@
+From b5021bcce9b95aa9f9b37e6599945aa6bf019904 Mon Sep 17 00:00:00 2001
+From: Alex Deryskyba <alex@codesnake.com>
+Date: Thu, 6 Nov 2014 08:14:39 +0200
+Subject: [PATCH 14/17] [aml] Remove dependency on libamplayer and amffmpeg
+
+---
+ xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp  |   79 +-------------------
+ .../DVDCodecs/Video/DVDVideoCodecAmlogic.cpp       |    3 -
+ 2 files changed, 3 insertions(+), 79 deletions(-)
+
+diff --git a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+index fcdad19..f3c67ea 100644
+--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
++++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+@@ -50,9 +50,9 @@
+ #include <stdlib.h>
+ #include <sys/ioctl.h>
+ 
+-// amcodec include
+ extern "C" {
+ #include <amcodec/codec.h>
++#include <libavutil/avutil.h>
+ }  // extern "C"
+ 
+ typedef struct {
+@@ -91,19 +91,11 @@ public:
+   virtual int codec_set_cntl_mode(codec_para_t *pcodec, unsigned int mode)=0;
+   virtual int codec_set_cntl_avthresh(codec_para_t *pcodec, unsigned int avthresh)=0;
+   virtual int codec_set_cntl_syncthresh(codec_para_t *pcodec, unsigned int syncthresh)=0;
+-
+-  // grab these from libamplayer
+-  virtual int h263vld(unsigned char *inbuf, unsigned char *outbuf, int inbuf_len, int s263)=0;
+-  virtual int decodeble_h263(unsigned char *buf)=0;
+-
+-  // grab this from amffmpeg so we do not have to load DllAvUtil
+-  virtual AVRational av_d2q(double d, int max)=0;
+ };
+ 
+ class DllLibAmCodec : public DllDynamic, DllLibamCodecInterface
+ {
+-  // libamcodec is static linked into libamplayer.so
+-  DECLARE_DLL_WRAPPER(DllLibAmCodec, "libamplayer.so")
++  DECLARE_DLL_WRAPPER(DllLibAmCodec, "libamcodec.so")
+ 
+   DEFINE_METHOD1(int, codec_init,               (codec_para_t *p1))
+   DEFINE_METHOD1(int, codec_close,              (codec_para_t *p1))
+@@ -121,11 +113,6 @@ class DllLibAmCodec : public DllDynamic, DllLibamCodecInterface
+   DEFINE_METHOD2(int, codec_set_cntl_avthresh,  (codec_para_t *p1, unsigned int p2))
+   DEFINE_METHOD2(int, codec_set_cntl_syncthresh,(codec_para_t *p1, unsigned int p2))
+ 
+-  DEFINE_METHOD4(int, h263vld,                  (unsigned char *p1, unsigned char *p2, int p3, int p4))
+-  DEFINE_METHOD1(int, decodeble_h263,           (unsigned char *p1))
+-
+-  DEFINE_METHOD2(AVRational, av_d2q,            (double p1, int p2))
+-
+   BEGIN_METHOD_RESOLVE()
+     RESOLVE_METHOD(codec_init)
+     RESOLVE_METHOD(codec_close)
+@@ -142,11 +129,6 @@ class DllLibAmCodec : public DllDynamic, DllLibamCodecInterface
+     RESOLVE_METHOD(codec_set_cntl_mode)
+     RESOLVE_METHOD(codec_set_cntl_avthresh)
+     RESOLVE_METHOD(codec_set_cntl_syncthresh)
+-
+-    RESOLVE_METHOD(h263vld)
+-    RESOLVE_METHOD(decodeble_h263)
+-
+-    RESOLVE_METHOD(av_d2q)
+   END_METHOD_RESOLVE()
+ 
+ public:
+@@ -345,8 +327,6 @@ typedef struct am_private_t
+   unsigned int      video_ratio64;
+   unsigned int      video_rate;
+   unsigned int      video_rotation_degree;
+-  int               flv_flag;
+-  int               h263_decodable;
+   int               extrasize;
+   uint8_t           *extradata;
+   DllLibAmCodec     *m_dll;
+@@ -439,7 +419,6 @@ static vformat_t codecid_to_vformat(enum AVCodecID id)
+     case AV_CODEC_ID_H263I:
+     case AV_CODEC_ID_MSMPEG4V2:
+     case AV_CODEC_ID_MSMPEG4V3:
+-    case AV_CODEC_ID_FLV1:
+       format = VFORMAT_MPEG4;
+       break;
+     case AV_CODEC_ID_RV10:
+@@ -1221,51 +1200,6 @@ int set_header_info(am_private_t *para)
+       {
+         return divx3_prefix(pkt);
+       }
+-      else if (para->video_codec_type == VIDEO_DEC_FORMAT_H263)
+-      {
+-        return PLAYER_UNSUPPORT;
+-        unsigned char *vld_buf;
+-        int vld_len, vld_buf_size = para->video_width * para->video_height * 2;
+-
+-        if (!pkt->data_size) {
+-            return PLAYER_SUCCESS;
+-        }
+-
+-        if ((pkt->data[0] == 0) && (pkt->data[1] == 0) && (pkt->data[2] == 1) && (pkt->data[3] == 0xb6)) {
+-            return PLAYER_SUCCESS;
+-        }
+-
+-        vld_buf = (unsigned char*)malloc(vld_buf_size);
+-        if (!vld_buf) {
+-            return PLAYER_NOMEM;
+-        }
+-
+-        if (para->flv_flag) {
+-            vld_len = para->m_dll->h263vld(pkt->data, vld_buf, pkt->data_size, 1);
+-        } else {
+-            if (0 == para->h263_decodable) {
+-                para->h263_decodable = para->m_dll->decodeble_h263(pkt->data);
+-                if (0 == para->h263_decodable) {
+-                    CLog::Log(LOGDEBUG, "[%s]h263 unsupport video and audio, exit", __FUNCTION__);
+-                    return PLAYER_UNSUPPORT;
+-                }
+-            }
+-            vld_len = para->m_dll->h263vld(pkt->data, vld_buf, pkt->data_size, 0);
+-        }
+-
+-        if (vld_len > 0) {
+-            if (pkt->buf) {
+-                free(pkt->buf);
+-            }
+-            pkt->buf = vld_buf;
+-            pkt->buf_size = vld_buf_size;
+-            pkt->data = pkt->buf;
+-            pkt->data_size = vld_len;
+-        } else {
+-            free(vld_buf);
+-            pkt->data_size = 0;
+-        }
+-      }
+     } else if (para->video_format == VFORMAT_VC1) {
+         if (para->video_codec_type == VIDEO_DEC_FORMAT_WMV3) {
+             unsigned i, check_sum = 0, data_len = 0;
+@@ -1458,7 +1392,7 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
+   am_private->video_pid        = hints.pid;
+ 
+   // handle video ratio
+-  AVRational video_ratio       = m_dll->av_d2q(1, SHRT_MAX);
++  AVRational video_ratio       = av_d2q(1, SHRT_MAX);
+   //if (!hints.forced_aspect)
+   //  video_ratio = m_dll->av_d2q(hints.aspect, SHRT_MAX);
+   am_private->video_ratio      = ((int32_t)video_ratio.num << 16) | video_ratio.den;
+@@ -1529,13 +1463,6 @@ bool CAMLCodec::OpenDecoder(CDVDStreamInfo &hints)
+   else
+     am_private->video_codec_type = codec_tag_to_vdec_type(am_private->video_codec_id);
+ 
+-  am_private->flv_flag = 0;
+-  if (am_private->video_codec_id == AV_CODEC_ID_FLV1)
+-  {
+-    am_private->video_codec_tag = CODEC_TAG_F263;
+-    am_private->flv_flag = 1;
+-  }
+-
+   CLog::Log(LOGDEBUG, "CAMLCodec::OpenDecoder "
+     "hints.width(%d), hints.height(%d), hints.codec(%d), hints.codec_tag(%d), hints.pid(%d)",
+     hints.width, hints.height, hints.codec, hints.codec_tag, hints.pid);
+diff --git a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+index 960aae1..57f8e40 100644
+--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
++++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecAmlogic.cpp
+@@ -108,9 +108,6 @@ bool CDVDVideoCodecAmlogic::Open(CDVDStreamInfo &hints, CDVDCodecOptions &option
+       // amcodec can't handle h263
+       return false;
+       break;
+-    case AV_CODEC_ID_FLV1:
+-      m_pFormatName = "am-flv1";
+-      break;
+     case AV_CODEC_ID_RV10:
+     case AV_CODEC_ID_RV20:
+     case AV_CODEC_ID_RV30:
+-- 
+1.7.10.4
+

--- a/alarm/kodi-c1-fb/PKGBUILD
+++ b/alarm/kodi-c1-fb/PKGBUILD
@@ -18,8 +18,8 @@ _prefix=/usr
 
 pkgbase=kodi-c1-fb
 pkgname=('kodi-c1-fb' 'kodi-c1-eventclients-fb')
-_commit=3a59f4b03708451273668022f415123522f634fd
-pkgver=15.2.20151030
+_commit=16.0b2-Jarvis
+pkgver=16.0.20151123
 pkgrel=1
 _codename=unknown
 arch=('armv7h')
@@ -33,17 +33,21 @@ makedepends=(
     'libxrandr' 'libxslt' 'lzo' 'nasm' 'nss-mdns' 'python2-pillow' 'aml-libs-c1' 
     'python2-pybluez' 'python2-simplejson' 'rtmpdump' 'sdl2' 'sdl_image' 
     'shairplay' 'smbclient' 'swig' 'taglib' 'tinyxml' 'unzip' 'upower' 'yajl' 
-    'zip'
+    'zip' 'dcadec-git' 'libcrossguid-git'
 )
-source=("https://github.com/Owersun/xbmc/archive/${_commit}.tar.gz"
+source=("https://github.com/xbmc/xbmc/archive/${_commit}.tar.gz"
         "git+https://github.com/mdrjr/c1_mali_libs.git"
+        'odroid-platform.patch'
+        '0014-aml-Remove-dependency-on-libamplayer-and-amffmpeg.patch'
         'kodi.service'
         'polkit.rules'
         'kodi_permissions.conf'
         '20-quiet-printk.conf')
 
-sha256sums=('96200ef955a65f9fa87a66b27b4374a2badd89d9a1d20c02f6fdca760f35a3ca'
+sha256sums=('b71f41f0786cb0e47c3f97c9ee18260488bdbc9565e3b8014d9b6d000ca53d6c'
             'SKIP'
+            '7aa09dd4ea776ec622848dc3d5d4f0bf3b64820038e0b6807f2876eaba01e9b4'
+            '6b5c36b14d8069b3ab78f672ff2c84ebd697eefc156ae7dca4a3965b9fe8ce47'
             '79aa17b475967d97b6c72c850b638705d6feb6d995844476b65d68d33d161114'
             'c68ed2bd377f80b606b8815d78239b9132b479eafc1d19797cee5824debe1800'
             'ecc413a1cfd4622b79de16010c9d8d269f774ad89d2e547553e36fbd236e8593'
@@ -51,6 +55,14 @@ sha256sums=('96200ef955a65f9fa87a66b27b4374a2badd89d9a1d20c02f6fdca760f35a3ca'
 
 prepare() {
   cd xbmc-${_commit}
+
+  # Add ODROID platform
+  patch -p1 < "${srcdir}/odroid-platform.patch"
+
+  # Add support for libamcodec.so instead of libamplayer.so
+  patch -p1 < "${srcdir}/0014-aml-Remove-dependency-on-libamplayer-and-amffmpeg.patch"
+
+  # Use Python 2 instead of Python 3
   find -type f -name *.py -exec sed 's|^#!.*python$|#!/usr/bin/python2|' -i "{}" +
   sed 's|^#!.*python$|#!/usr/bin/python2|' -i tools/depends/native/rpl-native/rpl
   sed 's/python/python2/' -i tools/Linux/kodi.sh.in

--- a/alarm/kodi-c1-fb/odroid-platform.patch
+++ b/alarm/kodi-c1-fb/odroid-platform.patch
@@ -1,0 +1,34 @@
+From 9d72ff9f149d052f2935be12b0eb717c5c5bb507 Mon Sep 17 00:00:00 2001
+From: Jan Holthuis <jan.holthuis@ruhr-uni-bochum.de>
+Date: Mon, 16 Nov 2015 14:21:12 +0100
+Subject: [PATCH] [AMLUtils] Add support for ODROID-C1(+)
+
+Hardkernel's ODROID-C1 (and its successor ODROID-C1+) are both
+single board computers that feature an Amlogic S805 / Meson8B chipset.
+
+Currently, they aren't recognized as Meson8B devices since they're
+missing "Meson8B" as Hardware identifier in /proc/cpuinfo and go with
+"ODROIDC" instead:
+
+    $ cat /proc/cpuinfo | grep Hardware
+    Hardware : ODROIDC
+
+This simple patch fixes this issue by adding "ODROIDC" as a valid
+identifier for AML_DEVICE_TYPE_M8B.
+---
+ xbmc/utils/AMLUtils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/utils/AMLUtils.cpp b/xbmc/utils/AMLUtils.cpp
+index 7f7ab62..bff3f4e 100644
+--- a/xbmc/utils/AMLUtils.cpp
++++ b/xbmc/utils/AMLUtils.cpp
+@@ -174,7 +174,7 @@ enum AML_DEVICE_TYPE aml_get_device_type()
+         aml_device_type = AML_DEVICE_TYPE_M8M2;
+       else
+         aml_device_type = AML_DEVICE_TYPE_M8;
+-    } else if (cpu_hardware.find("Meson8B") != std::string::npos)
++    } else if ((cpu_hardware.find("Meson8B") != std::string::npos) || (cpu_hardware.find("ODROIDC") != std::string::npos))
+       aml_device_type = AML_DEVICE_TYPE_M8B;
+     else
+       aml_device_type = AML_DEVICE_TYPE_UNKNOWN;


### PR DESCRIPTION
This bumps the kodi-c1-fb package to version 16.0 beta 2 (Jarvis).

This package now uses the mainline kodi repo. See this for details:
http://forum.odroid.com/viewtopic.php?f=112&t=15158&start=200#p113959
